### PR TITLE
Maintain 'username' field upon saving StormpathUser instances

### DIFF
--- a/django_stormpath/models.py
+++ b/django_stormpath/models.py
@@ -237,6 +237,7 @@ class StormpathBaseUser(AbstractBaseUser, StormpathPermissionsMixin):
         self.raw_password = raw_password
 
     def save(self, *args, **kwargs):
+        self.username = getattr(self, self.USERNAME_FIELD)
         # Are we updating an existing User?
         if self.id:
             self._update_for_db_and_stormpath(*args, **kwargs)


### PR DESCRIPTION
The creation form for a `StormpathUser` instance does not include the `username` field. Thus, when creating users from the Django admin console, the username field gets set to a blank value. When creating a second user using the admin console, we get an error about a unique key contraints being violated on field `username`.  

By maintaining the `username` field upon each save operation, we're preventing this.

I am wondering though why the `username` field is there in the first place if it's never editable in the admin...