### PR TITLE
Added migrations for all supported Django versions.

### DIFF
--- a/django_stormpath/migrations/0001_initial.py
+++ b/django_stormpath/migrations/0001_initial.py
@@ -2,12 +2,13 @@
 from __future__ import unicode_literals
 
 from django.db import models, migrations
+import django.utils.timezone
 
 
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('auth', '0006_require_contenttypes_0002'),
+        ('auth', '0001_initial'),
     ]
 
     operations = [
@@ -16,22 +17,23 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('password', models.CharField(max_length=128, verbose_name='password')),
-                ('last_login', models.DateTimeField(null=True, verbose_name='last login', blank=True)),
+                ('last_login', models.DateTimeField(default=django.utils.timezone.now, verbose_name='last login', null=True, blank=True)),
                 ('is_superuser', models.BooleanField(default=False, help_text='Designates that this user has all permissions without explicitly assigning them.', verbose_name='superuser status')),
                 ('href', models.CharField(max_length=255, null=True, blank=True)),
                 ('username', models.CharField(unique=True, max_length=255)),
                 ('given_name', models.CharField(max_length=255)),
                 ('surname', models.CharField(max_length=255)),
                 ('middle_name', models.CharField(max_length=255, null=True, blank=True)),
-                ('email', models.EmailField(unique=True, max_length=255, verbose_name='email address', db_index=True)),
+                ('email', models.EmailField(unique=True, max_length=255, verbose_name=b'email address', db_index=True)),
                 ('is_active', models.BooleanField(default=True)),
                 ('is_admin', models.BooleanField(default=False)),
                 ('is_staff', models.BooleanField(default=False)),
-                ('groups', models.ManyToManyField(related_query_name='user', related_name='user_set', to='auth.Group', blank=True, help_text='The groups this user belongs to. A user will get all permissions granted to each of their groups.', verbose_name='groups')),
+                ('groups', models.ManyToManyField(related_query_name='user', related_name='user_set', to='auth.Group', blank=True, help_text='The groups this user belongs to. A user will get all permissions granted to each of his/her group.', verbose_name='groups')),
                 ('user_permissions', models.ManyToManyField(related_query_name='user', related_name='user_set', to='auth.Permission', blank=True, help_text='Specific permissions for this user.', verbose_name='user permissions')),
             ],
             options={
                 'abstract': False,
             },
+            bases=(models.Model,),
         ),
     ]

--- a/django_stormpath/south_migrations/0001_initial.py
+++ b/django_stormpath/south_migrations/0001_initial.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'StormpathUser'
+        db.create_table(u'django_stormpath_stormpathuser', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('password', self.gf('django.db.models.fields.CharField')(max_length=128)),
+            ('last_login', self.gf('django.db.models.fields.DateTimeField')(default=datetime.datetime.now)),
+            ('is_superuser', self.gf('django.db.models.fields.BooleanField')(default=False)),
+            ('href', self.gf('django.db.models.fields.CharField')(max_length=255, null=True, blank=True)),
+            ('username', self.gf('django.db.models.fields.CharField')(unique=True, max_length=255)),
+            ('given_name', self.gf('django.db.models.fields.CharField')(max_length=255)),
+            ('surname', self.gf('django.db.models.fields.CharField')(max_length=255)),
+            ('middle_name', self.gf('django.db.models.fields.CharField')(max_length=255, null=True, blank=True)),
+            ('email', self.gf('django.db.models.fields.EmailField')(unique=True, max_length=255, db_index=True)),
+            ('is_active', self.gf('django.db.models.fields.BooleanField')(default=True)),
+            ('is_admin', self.gf('django.db.models.fields.BooleanField')(default=False)),
+            ('is_staff', self.gf('django.db.models.fields.BooleanField')(default=False)),
+        ))
+        db.send_create_signal(u'django_stormpath', ['StormpathUser'])
+
+        # Adding M2M table for field groups on 'StormpathUser'
+        m2m_table_name = db.shorten_name(u'django_stormpath_stormpathuser_groups')
+        db.create_table(m2m_table_name, (
+            ('id', models.AutoField(verbose_name='ID', primary_key=True, auto_created=True)),
+            ('stormpathuser', models.ForeignKey(orm[u'django_stormpath.stormpathuser'], null=False)),
+            ('group', models.ForeignKey(orm[u'auth.group'], null=False))
+        ))
+        db.create_unique(m2m_table_name, ['stormpathuser_id', 'group_id'])
+
+        # Adding M2M table for field user_permissions on 'StormpathUser'
+        m2m_table_name = db.shorten_name(u'django_stormpath_stormpathuser_user_permissions')
+        db.create_table(m2m_table_name, (
+            ('id', models.AutoField(verbose_name='ID', primary_key=True, auto_created=True)),
+            ('stormpathuser', models.ForeignKey(orm[u'django_stormpath.stormpathuser'], null=False)),
+            ('permission', models.ForeignKey(orm[u'auth.permission'], null=False))
+        ))
+        db.create_unique(m2m_table_name, ['stormpathuser_id', 'permission_id'])
+
+
+    def backwards(self, orm):
+        # Deleting model 'StormpathUser'
+        db.delete_table(u'django_stormpath_stormpathuser')
+
+        # Removing M2M table for field groups on 'StormpathUser'
+        db.delete_table(db.shorten_name(u'django_stormpath_stormpathuser_groups'))
+
+        # Removing M2M table for field user_permissions on 'StormpathUser'
+        db.delete_table(db.shorten_name(u'django_stormpath_stormpathuser_user_permissions'))
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'django_stormpath.stormpathuser': {
+            'Meta': {'object_name': 'StormpathUser'},
+            'email': ('django.db.models.fields.EmailField', [], {'unique': 'True', 'max_length': '255', 'db_index': 'True'}),
+            'given_name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            'href': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_admin': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'middle_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'surname': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'})
+        }
+    }
+
+    complete_apps = ['django_stormpath']


### PR DESCRIPTION
We need south_migrations directory with south migrations for Django 1.6 (https://docs.djangoproject.com/en/1.8/topics/migrations/#libraries-third-party-apps).
Also, for Django 1.7 and Django 1.8, we have to use migrations generated on Django 1.7 version (https://docs.djangoproject.com/en/1.8/topics/migrations/#supporting-multiple-django-versions). It should work on Django 1.8 (as stated in docs), but it doesn't - the last_login field was made nullable in 1.8. I changed that field in the migration, so it will work for both versions.