### PR TITLE
Removed Python 3.2 with Django 1.6 combination from matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,6 @@ env:
     - DJANGO=1.6.11
     - DJANGO=1.7.7
     - DJANGO=1.8
+    exclude:
+      - python: 3.2
+        env: DJANGO=1.6.11


### PR DESCRIPTION
South is not compatible with Python 3.2:
https://pypi.python.org/pypi/South
http://south.aeracode.org/ticket/1240