### PR TITLE
Removing Python 3.2 from Travis builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - '2.7'
-  - '3.2'
   - '3.3'
   - '3.4'
   - pypy
@@ -19,7 +18,3 @@ env:
   global:
     - secure: B6MEHOMJoQy9HMpb0Fxa7rNpQnOcBCR4cgad7BxtWSiU/vtI4l3iNUz5QtzgZFyhVya3snfBMeNGohMUpTSKr+yRl0rpE4gShVlDMSZwsKdXTqHHzpPp+Don56kKQ9kUthdl3tPmwwbPoatYJ3Jkwi+a3F1a2QLOTp03FGn0rUA=
     - secure: WvMLJkrK6gNa5bIIo3378j/JRu/sJISYDz4D23XBx91SUz32xQtRytQX+Tm5MqlE1963ZDe7jg1WJzBrHQXzRHC+GplrqlP5FtDKhnbUxAX4kqSGzeRWPxiwIwZr5N/iRe5dM3D0MTuT0ClAX2CsVFFWS/u2n3KDta9mkr4e6f8=
-matrix:
-    exclude:
-      - python: '3.2'
-        env: DJANGO=1.6.11


### PR DESCRIPTION
Python 3.2 is not compatible with South, and we need South migrations if we want to support Django 1.6. Travis tries to parse these files in south_migrations directory as Python sources even though they are not used for Django>=1.7.