### PR TITLE
Removed support for Python 3.2.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ Meta
 This library provides user account storage, authentication, and authorization
 with `Stormpath <https://stormpath.com>`_.
 
-This library works with Python 2.7.x and Python 3.x.
+This library works with Python 2.7.x and Python 3.3+.
 
 .. note::
     This library will NOT work on Google App Engine due to incompatibilities


### PR DESCRIPTION
SDK doesn't support it any more: https://github.com/stormpath/stormpath-sdk-python/commit/ec3159173fb801975523b38d4ea31002ba383339 .