### PR TITLE
Added get and get_or_create and update_or_create helpers.

### DIFF
--- a/django_stormpath/models.py
+++ b/django_stormpath/models.py
@@ -46,8 +46,47 @@ APPLICATION = CLIENT.applications.get(settings.STORMPATH_APPLICATION)
 
 class StormpathUserManager(BaseUserManager):
 
+    def get(self, *args, **kwargs):
+        try:
+            password = kwargs.pop('password')
+        except KeyError:
+            password = None
+
+        user = super(StormpathUserManager, self).get(*args, **kwargs)
+
+        if password:
+            try:
+                APPLICATION.authenticate_account(
+                    getattr(user, user.USERNAME_FIELD), password)
+            except StormpathError:
+                raise self.model.DoesNotExist
+
+        return user
+
     def create(self, *args, **kwargs):
         return self.create_user(*args, **kwargs)
+
+    def get_or_create(self, **kwargs):
+        try:
+            return self.get(**kwargs), False
+        except self.model.DoesNotExist:
+            return self.create(**kwargs), True
+
+    def update_or_create(self, defaults=None, **kwargs):
+        defaults = defaults or {}
+        try:
+            user = self.get(**kwargs)
+        except self.model.DoesNotExist:
+            kwargs.update(defaults)
+            return self.create(**kwargs), True
+
+        if 'password' in defaults:
+            user.set_password(defaults.pop('password'))
+        for k, v in defaults.items():
+            setattr(user, k, v)
+        user.save(using=self._db)
+        user._remove_raw_password()
+        return user, False
 
     def _create_user(self, email, given_name, surname, password):
         if not email:

--- a/testproject/testapp/tests.py
+++ b/testproject/testapp/tests.py
@@ -111,147 +111,147 @@ class TestUserAndGroups(LiveTestBase):
 
     def test_get_with_non_existing(self):
         UserModel.objects.create_user(
-            email='me@example.com', given_name='Sample', surname='User',
+            email='me1@example.com', given_name='Sample', surname='User',
             password='TestPassword123!')
         with self.assertRaises(UserModel.DoesNotExist):
             UserModel.objects.get(email='does.not@exist.com')
 
     def test_get_with_existing(self):
         UserModel.objects.create_user(
-            email='me@example.com', given_name='Sample', surname='User',
+            email='me2@example.com', given_name='Sample', surname='User',
             password='TestPassword123!')
         user = UserModel.objects.get(
-            email='me@example.com', given_name='Sample', surname='User',
+            email='me2@example.com', given_name='Sample', surname='User',
             password='TestPassword123!')
         self.assertTrue(user)
 
     def test_get_wrong_password(self):
         UserModel.objects.create_user(
-            email='me@example.com', given_name='Sample', surname='User',
+            email='me3@example.com', given_name='Sample', surname='User',
             password='TestPassword123!')
         with self.assertRaises(UserModel.DoesNotExist):
             UserModel.objects.get(
-                email='me@example.com', given_name='Sample', surname='User',
+                email='me3@example.com', given_name='Sample', surname='User',
                 password='wrong')
 
     def test_get_or_create_user_with_non_existing(self):
         user, created = UserModel.objects.get_or_create(
-            email='me@example.com', given_name='Sample', surname='User',
+            email='me4@example.com', given_name='Sample', surname='User',
             password='TestPassword123!')
 
         self.assertTrue(created)
         self.assertEqual(self.app.accounts.get(user.href).given_name, 'Sample')
-        user = UserModel.objects.get(email='me@example.com')
+        user = UserModel.objects.get(email='me4@example.com')
         self.assertEqual(user.surname, 'User')
         self.assertIsNotNone(
             StormpathBackend().authenticate(
-                'me@example.com', 'TestPassword123!'))
+                'me4@example.com', 'TestPassword123!'))
 
     def test_get_or_create_user_with_wrong_password(self):
         UserModel.objects.create_user(
-            email='me@example.com', given_name='Sample', surname='User',
+            email='me5@example.com', given_name='Sample', surname='User',
             password='TestPassword123!')
 
         with self.assertRaises(IntegrityError):
             user, created = UserModel.objects.get_or_create(
-                email='me@example.com', given_name='Sample', surname='User',
+                email='me5@example.com', given_name='Sample', surname='User',
                 password='wrong')
 
     def test_get_or_create_user_with_existing(self):
         UserModel.objects.create_user(
-            email='me@example.com', given_name='Sample', surname='User',
+            email='me6@example.com', given_name='Sample', surname='User',
             password='TestPassword123!')
         user, created = UserModel.objects.get_or_create(
-            email='me@example.com', given_name='Sample', surname='User',
+            email='me6@example.com', given_name='Sample', surname='User',
             password='TestPassword123!')
 
         self.assertFalse(created)
         self.assertEqual(self.app.accounts.get(user.href).given_name, 'Sample')
-        user = UserModel.objects.get(email='me@example.com')
+        user = UserModel.objects.get(email='me6@example.com')
         self.assertEqual(user.surname, 'User')
         self.assertIsNotNone(
             StormpathBackend().authenticate(
-                'me@example.com', 'TestPassword123!'))
+                'me6@example.com', 'TestPassword123!'))
 
     def test_update_or_create_user_with_non_existing(self):
         user, created = UserModel.objects.update_or_create(
             defaults={'given_name': 'Updated'},
-            email='me@example.com', given_name='Sample', surname='User',
+            email='me7@example.com', given_name='Sample', surname='User',
             password='TestPassword123!')
 
         self.assertTrue(created)
         self.assertEqual(
             self.app.accounts.get(user.href).given_name, 'Updated')
-        user = UserModel.objects.get(email='me@example.com')
+        user = UserModel.objects.get(email='me7@example.com')
         self.assertEqual(user.given_name, 'Updated')
         self.assertEqual(user.surname, 'User')
         self.assertIsNotNone(
             StormpathBackend().authenticate(
-                'me@example.com', 'TestPassword123!'))
+                'me7@example.com', 'TestPassword123!'))
 
     def test_update_or_create_user_with_wrong_password(self):
         UserModel.objects.create_user(
-            email='me@example.com', given_name='Sample', surname='User',
+            email='me8@example.com', given_name='Sample', surname='User',
             password='TestPassword123!')
 
         with self.assertRaises(IntegrityError):
             user, created = UserModel.objects.update_or_create(
                 defaults={'given_name': 'Updated'},
-                email='me@example.com', given_name='Sample', surname='User',
+                email='me8@example.com', given_name='Sample', surname='User',
                 password='123!TestPassword')
 
     def test_update_or_create_user_with_non_existing_and_password(self):
         user, created = UserModel.objects.update_or_create(
             defaults={'given_name': 'Updated', 'password': '123!TestPassword'},
-            email='me@example.com', given_name='Sample', surname='User',
+            email='me9@example.com', given_name='Sample', surname='User',
             password='TestPassword123!')
 
         self.assertTrue(created)
         self.assertEqual(
             self.app.accounts.get(user.href).given_name, 'Updated')
-        user = UserModel.objects.get(email='me@example.com')
+        user = UserModel.objects.get(email='me9@example.com')
         self.assertEqual(user.given_name, 'Updated')
         self.assertEqual(user.surname, 'User')
         self.assertIsNotNone(
             StormpathBackend().authenticate(
-                'me@example.com', '123!TestPassword'))
+                'me9@example.com', '123!TestPassword'))
 
     def test_update_or_create_user_with_existing(self):
         UserModel.objects.create_user(
-            email='me@example.com', given_name='Sample', surname='User',
+            email='me10@example.com', given_name='Sample', surname='User',
             password='TestPassword123!')
         user, created = UserModel.objects.update_or_create(
             defaults={'given_name': 'Updated'},
-            email='me@example.com', given_name='Sample', surname='User',
+            email='me10@example.com', given_name='Sample', surname='User',
             password='TestPassword123!')
 
         self.assertFalse(created)
         self.assertEqual(
             self.app.accounts.get(user.href).given_name, 'Updated')
-        user = UserModel.objects.get(email='me@example.com')
+        user = UserModel.objects.get(email='me10@example.com')
         self.assertEqual(user.given_name, 'Updated')
         self.assertEqual(user.surname, 'User')
         self.assertIsNotNone(
             StormpathBackend().authenticate(
-                'me@example.com', 'TestPassword123!'))
+                'me10@example.com', 'TestPassword123!'))
 
     def test_update_or_create_user_with_existing_and_password(self):
         UserModel.objects.create_user(
-            email='me@example.com', given_name='Sample', surname='User',
+            email='me11@example.com', given_name='Sample', surname='User',
             password='TestPassword123!')
         user, created = UserModel.objects.update_or_create(
             defaults={'given_name': 'Updated', 'password': '123!TestPassword'},
-            email='me@example.com', given_name='Sample', surname='User')
+            email='me11@example.com', given_name='Sample', surname='User')
 
         self.assertFalse(created)
         self.assertEqual(
             self.app.accounts.get(user.href).given_name, 'Updated')
-        user = UserModel.objects.get(email='me@example.com')
+        user = UserModel.objects.get(email='me11@example.com')
         self.assertEqual(user.given_name, 'Updated')
         self.assertEqual(user.surname, 'User')
         self.assertIsNotNone(
             StormpathBackend().authenticate(
-                'me@example.com', '123!TestPassword'))
+                'me11@example.com', '123!TestPassword'))
 
     def test_authentication_pulls_user_into_local_db(self):
         self.assertEqual(0, UserModel.objects.count())


### PR DESCRIPTION
I've added `get_or_create()` and `update_or_create()` helper functions for issue #50 . Overriding `_create_object_from_params` wouldn't help, as we have to mirror data from DB to Stormpath in the same way create_user() function does. Also, get and update parts of the functions were not working correctly for `StormpathUser`.