### PR TITLE
Password update fix

### DIFF
--- a/django_stormpath/models.py
+++ b/django_stormpath/models.py
@@ -151,9 +151,6 @@ class StormpathBaseUser(AbstractBaseUser, PermissionsMixin):
             if field in data:
                 del data[field]
 
-        if 'password' in data:
-            del data['password']
-
         account.status = account.STATUS_DISABLED if data['is_active'] is False else account.STATUS_ENABLED
 
         if 'is_active' in data:
@@ -218,6 +215,8 @@ class StormpathBaseUser(AbstractBaseUser, PermissionsMixin):
             return acc
         except StormpathError:
             raise self.DoesNotExist('Could not find Stormpath User.')
+        finally:
+            self._remove_raw_password()
 
     def get_full_name(self):
         return "%s %s" % (self.given_name, self.surname)

--- a/testproject/testapp/tests.py
+++ b/testproject/testapp/tests.py
@@ -386,6 +386,27 @@ class TestDjangoUser(LiveTestBase):
         self.assertEqual(user.first_name, a.given_name)
         self.assertEqual(user.first_name, a.given_name)
 
+    def test_updating_a_users_password(self):
+        user = self.create_django_user(
+                email='john.doe3@example.com',
+                first_name='John',
+                last_name='Doe',
+                password='TestPassword123!')
+        a = self.app.accounts.get(user.href)
+        self.assertEqual(user.href, a.href)
+
+        user.set_password('123!TestPassword')
+        self.assertTrue(hasattr(user, 'raw_password'))
+
+        user.save()
+
+        b = StormpathBackend()
+
+        self.assertFalse(hasattr(user, 'raw_password'))
+        self.assertFalse(user.has_usable_password())
+        self.assertTrue(b.authenticate(a.email, '123!TestPassword'))
+        self.assertFalse(b.authenticate(a.email, 'TestPassword123!'))
+
     def test_authentication_pulls_user_into_local_db(self):
         self.assertEqual(0, UserModel.objects.count())
         acc = self.app.accounts.create({


### PR DESCRIPTION
_mirror_data_from_db_user() used to delete password item from the data dict, which made updating password field impossible. This is removed so user's password can be updated.
test_updating_a_users_password() tests if password can be updated, and also checks that Django user has unusable password after the update and that raw_password field is removed.
It is important that passwords are saved in Stormpath, and not database Django uses. set_password() makes sure that Django password is unusable and sets password in raw_password field,
which _remove_raw_password() removes after StormpathUser is updated.

This also fixes the test that is failing in #57 - it is failing because password is not updated.