### PR TITLE
Change import to get_user_model to direct import to StormpathUser

### DIFF
--- a/django_stormpath/forms.py
+++ b/django_stormpath/forms.py
@@ -2,12 +2,11 @@
 """
 
 from django import forms
-from django.contrib.auth import get_user_model
 from django.contrib.auth.forms import ReadOnlyPasswordHashField
 
 from stormpath.error import Error
 
-from .models import APPLICATION
+from .models import StormpathUser, APPLICATION
 
 
 class StormpathUserCreationForm(forms.ModelForm):
@@ -22,7 +21,7 @@ class StormpathUserCreationForm(forms.ModelForm):
         widget=forms.PasswordInput)
 
     class Meta:
-        model = get_user_model()
+        model = StormpathUser
         fields = ("username", "email",
             "given_name", "surname", "password1", "password2")
 
@@ -89,7 +88,7 @@ class StormpathUserChangeForm(forms.ModelForm):
     """Update Stormpath user form."""
 
     class Meta:
-        model = get_user_model()
+        model = StormpathUser
         exclude = ('password',)
 
     password = ReadOnlyPasswordHashField(help_text=("Passwords are not stored in the local database "


### PR DESCRIPTION
Projects that use the app can have their own user model. They may don't want include fields you include in your model (like username, surname and given_name).