### PR TITLE
Converted email's verbose name from byte to str

### DIFF
--- a/django_stormpath/migrations/0003_auto_20160426_1425.py
+++ b/django_stormpath/migrations/0003_auto_20160426_1425.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('django_stormpath', '0002_auto_20150826_1154'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='stormpathuser',
+            name='email',
+            field=models.EmailField(db_index=True, max_length=255, unique=True, verbose_name='email address'),
+        ),
+    ]


### PR DESCRIPTION
We are running Django 1.9 in a Docker container with python3.  We started migrating to stormpath (django-stormpath 1.0.6).  When setting all the configuration settings, makemigrations detects a change in the stormpath app.

This is due to the [email's verbose name](https://github.com/stormpath/stormpath-django/blob/master/django_stormpath/migrations/0001_initial.py#L27) being defined as bytes instead of string (`b'email address'` vs `'email address'`), while the [model uses a string](https://github.com/michael-k/stormpath-django/blob/master/django_stormpath/models.py#L156).