### PR TITLE
Added ORGANIZATION_NAME_KEY setting for project-wide organization tenancy.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -336,6 +336,31 @@ official `Caching Docs <https://docs.stormpath.com/python/product-guide/#caching
 in our Python library.
 
 
+Multi-tenancy with Organizations
+--------------------------------
+
+Stormpath supports a
+`multi-tenancy <https://docs.stormpath.com/rest/product-guide/latest/multitenancy.html>`_
+model for user management based on Organizations. The ``Django-Stormpath`` plug-in
+provides limited support for multi-tenancy by allowing you to specify a
+configuration setting, STORMPATH_ORGANIZATION_NAME_KEY, that customizes these
+behaviors of the plug-in:
+
+- Which account store new accounts and groups are created in.
+- Which account store is searched first when authenticating a user.
+- Which set of constraints are used by the forms module to validate passwords.
+- Which account store's e-mail verification setting is consulted to determine
+  whether accounts are enabled (active) when first created.
+- How ID Site redirect URLs are composed.
+
+The STORMPATH_ORGANIZATION_NAME_KEY setting is optional, and if present it
+should contain a name key belonging to an Organization that is mapped as an
+account store to the application specified in the STORMPATH_APPLICATION
+setting. This is a static solution, intended to mandate the use of a single
+Organization over the entire lifetime of a running instance of a Django
+project.
+
+
 Copyright and License
 ---------------------
 

--- a/django_stormpath/backends.py
+++ b/django_stormpath/backends.py
@@ -1,5 +1,6 @@
 from logging import getLogger
 
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.db.models import Q
 from django.contrib.auth.backends import ModelBackend
@@ -29,7 +30,11 @@ class StormpathBackend(ModelBackend):
         """
         APPLICATION = get_application()
         try:
-            result = APPLICATION.authenticate_account(username, password)
+            result = APPLICATION.authenticate_account(
+                login=username,
+                password=password,
+                organization_name_key=getattr(settings, 'STORMPATH_ORGANIZATION_NAME_KEY', None)
+            )
             return result.account
         except Error as e:
             log.debug(e)

--- a/django_stormpath/helpers.py
+++ b/django_stormpath/helpers.py
@@ -1,7 +1,7 @@
 """Library helpers."""
 
 
-from django.core.exceptions import ImproperlyConfigured
+from django.core.exceptions import ImproperlyConfigured, ObjectDoesNotExist
 
 
 def validate_settings(settings):
@@ -14,3 +14,15 @@ def validate_settings(settings):
 
     if not settings.STORMPATH_APPLICATION:
         raise ImproperlyConfigured('STORMPATH_APPLICATION must be specified in settings.py.')
+
+
+def organization_if_any(settings, CLIENT):
+    """Obtain instance of organization if STORMPATH_ORGANIZATION_NAME_KEY set, otherwise None.
+
+    :param obj settings: The Django settings object.
+    :param obj CLIENT: The Python SDK client object."""
+    if hasattr(settings, 'STORMPATH_ORGANIZATION_NAME_KEY'):
+        found = CLIENT.organizations.query(name_key=settings.STORMPATH_ORGANIZATION_NAME_KEY)
+        if len(found) != 1:
+            raise ObjectDoesNotExist('No organization found matching STORMPATH_ORGANIZATION_NAME_KEY')
+        return found[0]

--- a/django_stormpath/views.py
+++ b/django_stormpath/views.py
@@ -23,7 +23,8 @@ def stormpath_callback(request, provider):
 def stormpath_id_site_login(request):
     rdr = APPLICATION.build_id_site_redirect_url(
             callback_uri=settings.STORMPATH_ID_SITE_CALLBACK_URI,
-            state=request.GET.get('state'))
+            state=request.GET.get('state'),
+            organization_name_key=getattr(settings, 'STORMPATH_ORGANIZATION_NAME_KEY', None))
     return redirect(rdr)
 
 
@@ -31,7 +32,8 @@ def stormpath_id_site_register(request):
     rdr = APPLICATION.build_id_site_redirect_url(
             callback_uri=settings.STORMPATH_ID_SITE_CALLBACK_URI,
             state=request.GET.get('state'),
-            path="/#/register")
+            path="/#/register",
+            organization_name_key=getattr(settings, 'STORMPATH_ORGANIZATION_NAME_KEY', None))
     return redirect(rdr)
 
 
@@ -39,7 +41,8 @@ def stormpath_id_site_forgot_password(request):
     rdr = APPLICATION.build_id_site_redirect_url(
             callback_uri=settings.STORMPATH_ID_SITE_CALLBACK_URI,
             state=request.GET.get('state'),
-            path="/#/forgot")
+            path="/#/forgot",
+            organization_name_key=getattr(settings, 'STORMPATH_ORGANIZATION_NAME_KEY', None))
     return redirect(rdr)
 
 
@@ -47,7 +50,8 @@ def stormpath_id_site_logout(request):
     rdr = APPLICATION.build_id_site_redirect_url(
             callback_uri=settings.STORMPATH_ID_SITE_CALLBACK_URI,
             state=request.GET.get('state'),
-            logout=True)
+            logout=True,
+            organization_name_key=getattr(settings, 'STORMPATH_ORGANIZATION_NAME_KEY', None))
     return redirect(rdr)
 
 


### PR DESCRIPTION
An optional `STORMPATH_ORGANIZATION_NAME_KEY` setting directs the plug-in to create new accounts and groups in an organization's account store (rather than the application's default store) and customizes other account-store-specific behaviors such as password strength policy so that they are derived from the organization rather than the application's default store. Details of behaviors affected by this setting are enumerated in the README.